### PR TITLE
New feature: external settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ A demo OPC UA server application, **currently in development**, that fetches wea
 - Make sure you have the two libraries [open62541](https://open62541.org/) and [C++ REST SDK](https://github.com/Microsoft/cpprestsdk) included in your project.It is expected that amalgamated open62541 header and source files are located at folder ..\..\open62541-Single-File and C++ REST SDK - under vcpkg folder ..\..\vcpkg\installed\x64-windows, relatively to the VC project folder.
 - To fetch weather data, you will use the API from [DarkSky API - Weather](https://darksky.net/dev). 
 	* If you do not already have an account, you will need to [create one](https://darksky.net/dev/register) in order to request an API Key.
-	* In `WebService.cpp` class implementation, replace the value of `WebService::KEY_API_DARKSKY` constant with your own API KEY that you received from your registration above. You can go directly to this constant location searching for TODO in the project.
-- Check the `TODO` in the `WebService.cpp` source code,  the constant `INTERVAL_DOWNLOAD_WEATHER_DATA` controls the interval in minutes of the download of weather data.
+- Open the `settings.json` inside the visual studio project folder and follow the instructions:
+	* Under the `darksky_api` object, you may change:
+		* **(REQUIRED)** The value of "api_key" parameter with your API KEY that you received from your registration above.
+		* **(OPTIONAL)** The value of "interval_download" parameter to control the interval in **minutes** of the download of weather data.
+- Pass the path to the `settings.json` file as an command line argument before run.
 - Build & run!
 
 ## Project Overview

--- a/aqw-opcua-server/CountryData.cpp
+++ b/aqw-opcua-server/CountryData.cpp
@@ -1,19 +1,17 @@
 #include "CountryData.h"
 
-using namespace weathersvr;
+const utility::string_t weathersvr::CountryData::KEY_NAME = U("name");
+const utility::string_t weathersvr::CountryData::KEY_CODE = U("code");
+const utility::string_t weathersvr::CountryData::KEY_CITIES = U("cities");
+const utility::string_t weathersvr::CountryData::KEY_LOCATIONS = U("locations");
 
-const utility::string_t CountryData::KEY_NAME = U("name");
-const utility::string_t CountryData::KEY_CODE = U("code");
-const utility::string_t CountryData::KEY_CITIES = U("cities");
-const utility::string_t CountryData::KEY_LOCATIONS = U("locations");
+char weathersvr::CountryData::COUNTRIES_FOLDER_NODE_ID[] = "Countries";
+char weathersvr::CountryData::BROWSE_NAME[] = "CountryName";
+char weathersvr::CountryData::BROWSE_CODE[] = "CountryCode";
+char weathersvr::CountryData::BROWSE_CITIES_NUMBER[] = "CountryCitiesNumber";
+char weathersvr::CountryData::BROWSE_LOCATIONS_NUMBER[] = "CountryLocationsNumber";
 
-char CountryData::COUNTRIES_FOLDER_NODE_ID[] = "Countries";
-char CountryData::BROWSE_NAME[] = "CountryName";
-char CountryData::BROWSE_CODE[] = "CountryCode";
-char CountryData::BROWSE_CITIES_NUMBER[] = "CountryCitiesNumber";
-char CountryData::BROWSE_LOCATIONS_NUMBER[] = "CountryLocationsNumber";
-
-CountryData::CountryData(std::string name, std::string code, uint32_t cities, uint32_t locations, bool isInitialized)
+weathersvr::CountryData::CountryData(std::string name, std::string code, uint32_t cities, uint32_t locations, bool isInitialized)
 	: name {name}, code {code}, citiesNumber {cities}, locationsNumber {locations}, isInitialized {isInitialized}
 {}
 
@@ -21,7 +19,7 @@ weathersvr::CountryData::CountryData(std::string code)
 	: CountryData {"", code, 0, 0}
 {}
 
-CountryData CountryData::parseJson(web::json::value& json) {
+weathersvr::CountryData weathersvr::CountryData::parseJson(web::json::value& json) {
 	return CountryData(
 		utility::conversions::to_utf8string(json.at(KEY_NAME).as_string()), // Converts from wstring to string
 		utility::conversions::to_utf8string(json.at(KEY_CODE).as_string()),
@@ -29,7 +27,7 @@ CountryData CountryData::parseJson(web::json::value& json) {
 		json.at(KEY_LOCATIONS).as_integer());;
 }
 
-std::vector<CountryData> CountryData::parseJsonArray(web::json::value& jsonArray) {
+std::vector<weathersvr::CountryData> weathersvr::CountryData::parseJsonArray(web::json::value& jsonArray) {
 	std::vector<CountryData> vectorAllCountries;
 	if (jsonArray.is_array()) {
 		for (size_t i {0}; i < jsonArray.size(); i++) {

--- a/aqw-opcua-server/LocationData.cpp
+++ b/aqw-opcua-server/LocationData.cpp
@@ -1,17 +1,15 @@
 #include "LocationData.h"
 
-using namespace weathersvr;
+const utility::string_t weathersvr::LocationData::KEY_NAME = U("location");
+const utility::string_t weathersvr::LocationData::KEY_CITY_NAME = U("city");
+const utility::string_t weathersvr::LocationData::KEY_COUNTRY_CODE = U("country");
+const utility::string_t weathersvr::LocationData::KEY_COORDINATES = U("coordinates");
+const utility::string_t weathersvr::LocationData::KEY_LATITUDE = U("latitude");
+const utility::string_t weathersvr::LocationData::KEY_LONGITUDE = U("longitude");
+const short weathersvr::LocationData::INVALID_LATITUDE = 91;
+const short weathersvr::LocationData::INVALID_LONGITUDE = 181;
 
-const utility::string_t LocationData::KEY_NAME = U("location");
-const utility::string_t LocationData::KEY_CITY_NAME = U("city");
-const utility::string_t LocationData::KEY_COUNTRY_CODE = U("country");
-const utility::string_t LocationData::KEY_COORDINATES = U("coordinates");
-const utility::string_t LocationData::KEY_LATITUDE = U("latitude");
-const utility::string_t LocationData::KEY_LONGITUDE = U("longitude");
-const short LocationData::INVALID_LATITUDE = 91;
-const short LocationData::INVALID_LONGITUDE = 181;
-
-char LocationData::BROWSE_FLAG_INITIALIZE[] = "FlagInitialize";
+char weathersvr::LocationData::BROWSE_FLAG_INITIALIZE[] = "FlagInitialize";
 
 weathersvr::LocationData::LocationData(std::string name, std::string city, std::string countryCode,	double latitude, double longitude, 
 	bool hasBeenReceivedWeatherData, bool isInitialized, bool isAddingWeatherToAddressSpace)
@@ -25,7 +23,7 @@ weathersvr::LocationData::LocationData(std::string name, std::string countryCode
 	: LocationData {name, "", countryCode, INVALID_LATITUDE, INVALID_LONGITUDE}
 {}
 
-LocationData LocationData::parseJson(web::json::value& json) {
+weathersvr::LocationData weathersvr::LocationData::parseJson(web::json::value& json) {
 	// Converts from wstring to string
 	std::string lName = utility::conversions::to_utf8string(json.at(KEY_NAME).as_string());
 	std::string lCity = utility::conversions::to_utf8string(json.at(KEY_CITY_NAME).as_string());
@@ -45,7 +43,7 @@ LocationData LocationData::parseJson(web::json::value& json) {
 	return LocationData(lName, lCity, lCountryCode, lLatitude, lLongittude);
 }
 
-std::vector<LocationData> LocationData::parseJsonArray(web::json::value& jsonArray) {
+std::vector<weathersvr::LocationData> weathersvr::LocationData::parseJsonArray(web::json::value& jsonArray) {
 	std::vector<LocationData> vectorAllLocations;
 	if (jsonArray.is_array()) {
 		for (size_t i {0}; i < jsonArray.size(); i++) {

--- a/aqw-opcua-server/Settings.cpp
+++ b/aqw-opcua-server/Settings.cpp
@@ -1,0 +1,47 @@
+#include "Settings.h"
+
+const utility::string_t weathersvr::Settings::OPC_UA_SERVER = U("opc_ua_server");
+const utility::string_t weathersvr::Settings::API_OPENAQ = U("openaq_api");
+const utility::string_t weathersvr::Settings::API_DARKSKY = U("darksky_api");
+const utility::string_t weathersvr::Settings::PARAM_NAME_API_DARKSKY_API_KEY = U("api_key");
+const utility::string_t weathersvr::Settings::PARAM_NAME_API_DARKSKY_UNITS = U("param_units");
+const utility::string_t weathersvr::Settings::PARAM_NAME_API_DARKSKY_INTERVAL_DOWNLOAD_WEATHER_DATA = U("interval_download");
+
+weathersvr::Settings::Settings() {
+	setDefaultValues();
+}
+
+void weathersvr::Settings::setup(char * fileName) {
+	try {
+		std::fstream inputFile {fileName};
+
+		std::cout << "################################################" << std::endl;
+		if (!inputFile) {
+			std::cerr << "Could not open the settings file: " << fileName << std::endl;
+			std::cerr << "Check if the file name and extension are correctly. Also check if the path to the file was passed correctly." << std::endl;
+			std::cout << "################################################" << std::endl << std::endl;
+			return;
+		}
+		std::cout << "Building settings..." << std::endl;
+
+		auto jsonFile = web::json::value::parse(inputFile);
+		auto darkSkyObj = jsonFile.at(API_DARKSKY);
+
+		// Set the values from the Json file's DarkSky object.
+		keyApiDarksky = darkSkyObj.at(PARAM_NAME_API_DARKSKY_API_KEY).as_string();
+		units = darkSkyObj.at(PARAM_NAME_API_DARKSKY_UNITS).as_string();
+		intervalDownloadWeatherData = static_cast<short>(darkSkyObj.at(PARAM_NAME_API_DARKSKY_INTERVAL_DOWNLOAD_WEATHER_DATA).as_integer());
+
+		std::cout << "Build completed successfully!!!" << std::endl;
+	} catch (const web::json::json_exception& e) {
+		std::cerr << "Error parsing the settings json file: " << e.what() << std::endl;
+		std::cerr << "Default values will be used (Except for the DarkSky API_KEY)" << std::endl;
+	}
+	std::cout << "################################################" << std::endl << std::endl;
+}
+
+void weathersvr::Settings::setDefaultValues() {
+	keyApiDarksky = U("");
+	units = U("si");
+	intervalDownloadWeatherData = 10;
+}

--- a/aqw-opcua-server/Settings.h
+++ b/aqw-opcua-server/Settings.h
@@ -7,9 +7,11 @@ namespace weathersvr {
 	class Settings {
 	public:
 		Settings();
-
+		/*
+		Open the file passed to the formal parameter fileName and set the settings to variables of this class.
+		@param char* fileName - the path containing the settings file name and extension that is passed to command line arguments.
+		*/
 		void setup(char* fileName);
-		void setDefaultValues();
 
 		const utility::string_t& getKeyApiDarksky() const { return keyApiDarksky; }
 		const utility::string_t& getUnits() const { return units; }
@@ -22,6 +24,14 @@ namespace weathersvr {
 		static const utility::string_t PARAM_NAME_API_DARKSKY_UNITS;
 		static const utility::string_t PARAM_NAME_API_DARKSKY_INTERVAL_DOWNLOAD_WEATHER_DATA;
 	private:
+		void setDefaultValues();
+		/*
+		Check if the values present in the settings.json file related to the dark sky api are valid before set them to respective variables. If is not valid, the default values will be kept.
+		This function may throw an exception web::json::json_exception.
+		@param web::json::value& jsonObj - The Json OBJECT which the values will be parsed and validated.
+		*/
+		void validateValuesFromDarkSky(web::json::value& jsonObj);
+
 		utility::string_t keyApiDarksky;
 		utility::string_t units;
 		short intervalDownloadWeatherData;

--- a/aqw-opcua-server/Settings.h
+++ b/aqw-opcua-server/Settings.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "cpprest/http_client.h"
+#include <fstream>
+#include <iostream>
+
+namespace weathersvr {
+	class Settings {
+	public:
+		Settings();
+
+		void setup(char* fileName);
+		void setDefaultValues();
+
+		const utility::string_t& getKeyApiDarksky() const { return keyApiDarksky; }
+		const utility::string_t& getUnits() const { return units; }
+		const short getIntervalDownloadWeatherData() const { return intervalDownloadWeatherData; }
+
+		static const utility::string_t OPC_UA_SERVER;
+		static const utility::string_t API_OPENAQ;
+		static const utility::string_t API_DARKSKY;
+		static const utility::string_t PARAM_NAME_API_DARKSKY_API_KEY;
+		static const utility::string_t PARAM_NAME_API_DARKSKY_UNITS;
+		static const utility::string_t PARAM_NAME_API_DARKSKY_INTERVAL_DOWNLOAD_WEATHER_DATA;
+	private:
+		utility::string_t keyApiDarksky;
+		utility::string_t units;
+		short intervalDownloadWeatherData;
+	};
+}

--- a/aqw-opcua-server/WeatherData.cpp
+++ b/aqw-opcua-server/WeatherData.cpp
@@ -1,29 +1,27 @@
 #include "WeatherData.h"
 
-using namespace weathersvr;
+const utility::string_t weathersvr::WeatherData::KEY_LATITUDE = U("latitude");
+const utility::string_t weathersvr::WeatherData::KEY_LONGITUDE = U("longitude");
+const utility::string_t weathersvr::WeatherData::KEY_TIMEZONE = U("timezone");
+const utility::string_t weathersvr::WeatherData::KEY_ICON = U("icon");
+const utility::string_t weathersvr::WeatherData::KEY_TEMPERATURE = U("temperature");
+const utility::string_t weathersvr::WeatherData::KEY_APARENT_TEMPERATURE = U("apparentTemperature");
+const utility::string_t weathersvr::WeatherData::KEY_HUMIDIY = U("humidity");
+const utility::string_t weathersvr::WeatherData::KEY_PRESSURE = U("pressure");
+const utility::string_t weathersvr::WeatherData::KEY_WINDSPEED = U("windSpeed");
+const utility::string_t weathersvr::WeatherData::KEY_CLOUD_COVER = U("cloudCover");
+const utility::string_t weathersvr::WeatherData::KEY_CURRENTLY = U("currently");
 
-const utility::string_t WeatherData::KEY_LATITUDE = U("latitude");
-const utility::string_t WeatherData::KEY_LONGITUDE = U("longitude");
-const utility::string_t WeatherData::KEY_TIMEZONE = U("timezone");
-const utility::string_t WeatherData::KEY_ICON = U("icon");
-const utility::string_t WeatherData::KEY_TEMPERATURE = U("temperature");
-const utility::string_t WeatherData::KEY_APARENT_TEMPERATURE = U("apparentTemperature");
-const utility::string_t WeatherData::KEY_HUMIDIY = U("humidity");
-const utility::string_t WeatherData::KEY_PRESSURE = U("pressure");
-const utility::string_t WeatherData::KEY_WINDSPEED = U("windSpeed");
-const utility::string_t WeatherData::KEY_CLOUD_COVER = U("cloudCover");
-const utility::string_t WeatherData::KEY_CURRENTLY = U("currently");
-
-char WeatherData::BROWSE_LATITUDE[] = "Latitude";
-char WeatherData::BROWSE_LONGITUDE[] = "Longitude";
-char WeatherData::BROWSE_TIMEZONE[] = "Timezone";
-char WeatherData::BROWSE_ICON[] = "Icon";
-char WeatherData::BROWSE_TEMPERATURE[] = "Temperature";
-char WeatherData::BROWSE_APPARENT_TEMPERATURE[] = "ApparentTemperature";
-char WeatherData::BROWSE_HUMIDITY[] = "Humidity";
-char WeatherData::BROWSE_PRESSURE[] = "Pressure";
-char WeatherData::BROWSE_WIND_SPEED[] = "WindSpeed";
-char WeatherData::BROWSE_CLOUD_COVER[] = "CloudCover";
+char weathersvr::WeatherData::BROWSE_LATITUDE[] = "Latitude";
+char weathersvr::WeatherData::BROWSE_LONGITUDE[] = "Longitude";
+char weathersvr::WeatherData::BROWSE_TIMEZONE[] = "Timezone";
+char weathersvr::WeatherData::BROWSE_ICON[] = "Icon";
+char weathersvr::WeatherData::BROWSE_TEMPERATURE[] = "Temperature";
+char weathersvr::WeatherData::BROWSE_APPARENT_TEMPERATURE[] = "ApparentTemperature";
+char weathersvr::WeatherData::BROWSE_HUMIDITY[] = "Humidity";
+char weathersvr::WeatherData::BROWSE_PRESSURE[] = "Pressure";
+char weathersvr::WeatherData::BROWSE_WIND_SPEED[] = "WindSpeed";
+char weathersvr::WeatherData::BROWSE_CLOUD_COVER[] = "CloudCover";
 
 weathersvr::WeatherData::WeatherData(double latitude, double longitude, std::string timezone, std::string icon, 
 	double temperature, double apparentTemperature, double humidity, double pressure, double windSpeed, double cloudCover)
@@ -36,7 +34,7 @@ weathersvr::WeatherData::WeatherData()
 	: WeatherData {0, 0, "", "", 0, 0, 0, 0, 0, 0}
 {}
 
-WeatherData weathersvr::WeatherData::parseJson(web::json::value & json) {
+weathersvr::WeatherData weathersvr::WeatherData::parseJson(web::json::value & json) {
 	double latitude = json.at(KEY_LATITUDE).as_double();
 	double longitude = json.at(KEY_LONGITUDE).as_double();
 	std::string timezone = utility::conversions::to_utf8string(json.at(KEY_TIMEZONE).as_string()); // Converts from wstring to string

--- a/aqw-opcua-server/WebService.cpp
+++ b/aqw-opcua-server/WebService.cpp
@@ -1,27 +1,21 @@
 #include "WebService.h"
 
-using namespace weathersvr;
+const uint16_t weathersvr::WebService::OPC_NS_INDEX = 1;
+const utility::string_t weathersvr::WebService::ENDPOINT_API_OPENAQ = U("https://api.openaq.org/v1/");
+const utility::string_t weathersvr::WebService::PATH_API_OPENAQ_COUNTRIES = U("countries");
+const utility::string_t weathersvr::WebService::PATH_API_OPENAQ_LOCATIONS = U("locations");
+const utility::string_t weathersvr::WebService::PATH_API_OPENAQ_MEASUREMENTS = U("measurements");
+const utility::string_t weathersvr::WebService::PARAM_API_OPENAQ_COUNTRY = U("country");
+const utility::string_t weathersvr::WebService::PARAM_API_OPENAQ_LIMIT = U("limit");
 
-const uint16_t WebService::OPC_NS_INDEX = 1;
-const utility::string_t WebService::ENDPOINT_API_OPENAQ = U("https://api.openaq.org/v1/");;
-const utility::string_t WebService::PATH_API_OPENAQ_COUNTRIES = U("countries");
-const utility::string_t WebService::PATH_API_OPENAQ_LOCATIONS = U("locations");
-const utility::string_t WebService::PATH_API_OPENAQ_MEASUREMENTS = U("measurements");
-const utility::string_t WebService::PARAM_API_OPENAQ_COUNTRY = U("country");
-const utility::string_t WebService::PARAM_API_OPENAQ_LIMIT = U("limit");
+const utility::string_t weathersvr::WebService::ENDPOINT_API_DARKSKY = U("https://api.darksky.net/forecast");
+const utility::string_t weathersvr::WebService::PARAM_API_DARKSKY_EXCLUDE = U("exclude");
+const utility::string_t weathersvr::WebService::PARAM_API_DARKSKY_UNITS = U("units");
+const std::string weathersvr::WebService::PARAM_VALUE_API_DARKSKY_MINUTELY = "minutely";
+const std::string weathersvr::WebService::PARAM_VALUE_API_DARKSKY_HOURLY = "hourly";
+const std::string weathersvr::WebService::PARAM_VALUE_API_DARKSKY_DAILY = "daily";
 
-const utility::string_t WebService::ENDPOINT_API_DARKSKY = U("https://api.darksky.net/forecast");
-// TODO: Replace the value of this constant with your DarkSky API Key
-const utility::string_t WebService::KEY_API_DARKSKY = U("");
-const utility::string_t WebService::PARAM_API_DARKSKY_EXCLUDE = U("exclude");
-const utility::string_t WebService::PARAM_API_DARKSKY_UNITS = U("units");
-const std::string WebService::PARAM_VALUE_API_DARKSKY_MINUTELY = "minutely";
-const std::string WebService::PARAM_VALUE_API_DARKSKY_HOURLY = "hourly";
-const std::string WebService::PARAM_VALUE_API_DARKSKY_DAILY = "daily";
-// TODO: Change the interval in minutes to control the download of weather data.
-const short WebService::INTERVAL_DOWNLOAD_WEATHER_DATA = 15;
-
-pplx::task<web::json::value> WebService::fetchAllCountries() {
+pplx::task<web::json::value> weathersvr::WebService::fetchAllCountries() {
 
 	web::uri_builder uriBuilder(ENDPOINT_API_OPENAQ);
 	uriBuilder.append_path(PATH_API_OPENAQ_COUNTRIES);
@@ -42,7 +36,7 @@ pplx::task<web::json::value> WebService::fetchAllCountries() {
 	});
 }
 
-pplx::task<web::json::value> WebService::fetchAllLocations(const std::string& countryName, const uint32_t limit) {
+pplx::task<web::json::value> weathersvr::WebService::fetchAllLocations(const std::string& countryName, const uint32_t limit) {
 	web::uri_builder uriBuilder(ENDPOINT_API_OPENAQ);
 	uriBuilder.append_path(PATH_API_OPENAQ_LOCATIONS);
 	uriBuilder.append_query(PARAM_API_OPENAQ_COUNTRY, utility::conversions::to_string_t(countryName));
@@ -71,11 +65,11 @@ pplx::task<web::json::value> weathersvr::WebService::fetchWeather(const double& 
 		+ "," + WebService::PARAM_VALUE_API_DARKSKY_DAILY;
 
 	web::uri_builder uriBuilder(ENDPOINT_API_DARKSKY);
-	uriBuilder.append_path(KEY_API_DARKSKY);
+	uriBuilder.append_path(settings.getKeyApiDarksky());
 	uriBuilder.append_path(utility::conversions::to_string_t(coordinatesPath));
 	uriBuilder.append_query(WebService::PARAM_API_DARKSKY_EXCLUDE, 
 		utility::conversions::to_string_t(excludeQuery));
-	uriBuilder.append_query(WebService::PARAM_API_DARKSKY_UNITS, U("si"));
+	uriBuilder.append_query(WebService::PARAM_API_DARKSKY_UNITS, settings.getUnits());
 
 	web::http::client::http_client client(uriBuilder.to_string());
 	return client.request(web::http::methods::GET)
@@ -96,6 +90,10 @@ void weathersvr::WebService::setServer(UA_Server * uaServer) {
 	server = uaServer;
 }
 
-void WebService::setAllCountries(const std::vector<CountryData>& allCountries) {
+void weathersvr::WebService::setSettings(const Settings& settingsObj) {
+	settings = settingsObj;
+}
+
+void weathersvr::WebService::setAllCountries(const std::vector<CountryData>& allCountries) {
 	fetchedAllCountries = allCountries;
 }

--- a/aqw-opcua-server/WebService.h
+++ b/aqw-opcua-server/WebService.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "cpprest/http_client.h"
 #include "open62541.h"
+#include "Settings.h"
 #include "CountryData.h"
 #include "LocationData.h"
 #include "WeatherData.h"
@@ -36,9 +37,11 @@ namespace weathersvr {
 		pplx::task<web::json::value> fetchWeather(const double& latitude, const double& longitude);
 		
 		void setServer(UA_Server* uaServer);
+		void setSettings(const Settings& settingsObj);
 		void setAllCountries(const std::vector<CountryData>& allCountries);
 
 		UA_Server* getServer() { return server; }
+		const Settings& getSettings() { return settings; }
 		std::vector<CountryData>& getAllCountries() { return fetchedAllCountries; }
 	
 		// Constants endpoints, keys, paths, querys etc to all the API services.
@@ -51,13 +54,11 @@ namespace weathersvr {
 		static const utility::string_t PARAM_API_OPENAQ_LIMIT;
 
 		static const utility::string_t ENDPOINT_API_DARKSKY;
-		static const utility::string_t KEY_API_DARKSKY;
 		static const utility::string_t PARAM_API_DARKSKY_EXCLUDE;
 		static const utility::string_t PARAM_API_DARKSKY_UNITS;
 		static const std::string PARAM_VALUE_API_DARKSKY_MINUTELY;
 		static const std::string PARAM_VALUE_API_DARKSKY_HOURLY;
 		static const std::string PARAM_VALUE_API_DARKSKY_DAILY;
-		static const short INTERVAL_DOWNLOAD_WEATHER_DATA;
 
 		/* DarkSky URI example:
 		https://api.darksky.net/forecast/KEY/latitude,longitude?exclude=minutely,hourly,daily?units=si 
@@ -69,6 +70,7 @@ namespace weathersvr {
 
 	private:
 		UA_Server* server {nullptr};
+		Settings settings;
 		std::vector<CountryData> fetchedAllCountries {};
 	};
 }

--- a/aqw-opcua-server/aqw-opcua-server.vcxproj
+++ b/aqw-opcua-server/aqw-opcua-server.vcxproj
@@ -133,12 +133,14 @@
     <ClCompile Include="CountryData.cpp" />
     <ClCompile Include="LocationData.cpp" />
     <ClCompile Include="open62541.c" />
+    <ClCompile Include="Settings.cpp" />
     <ClCompile Include="WeatherData.cpp" />
     <ClCompile Include="WebService.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CountryData.h" />
     <ClInclude Include="LocationData.h" />
+    <ClInclude Include="Settings.h" />
     <ClInclude Include="WeatherData.h" />
     <ClInclude Include="WebService.h" />
   </ItemGroup>

--- a/aqw-opcua-server/aqw-opcua-server.vcxproj.filters
+++ b/aqw-opcua-server/aqw-opcua-server.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="WebService.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Settings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CountryData.h">
@@ -45,6 +48,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WebService.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,13 @@
+{
+  "opc_ua_server": {
+
+  },
+  "openaq_api": {
+
+  },
+  "darksky_api": {
+    "api_key": "PUT YOUR API KEY FROM DARK SKY HERE",
+    "param_units": "si",
+    "interval_download": 15
+  }
+}


### PR DESCRIPTION
@RavilN 
Please, check the new feature added. Now it's possible to configure externally the API KEY, units of weather information and interval in minutes of automatic update from the weather data. The settings file needs to be passed as command line arguments. There is also a validation check in case of unsuccessful startup of settings file.
Also Some bugs were fixed on the master repository (limit download and weather data) before this branch be created.